### PR TITLE
Use full PGP key fingerprint in apt source

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -39,7 +39,7 @@ class logstashforwarder::repo {
         location    => 'http://packages.elasticsearch.org/logstashforwarder/debian',
         release     => 'stable',
         repos       => 'main',
-        key         => 'D88E42B4',
+        key         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
         key_source  => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
         include_src => false,
       }


### PR DESCRIPTION
Apt puppet module requires to use full fingerprints (40 characters)
for apt source keys.

Apt module shows this warning:
```
/Apt_key[Add key: D88E42B4 from Apt::Source logstashforwarder] | The id should be a full fingerprint (40 characters), see README.
```


